### PR TITLE
id를 가진 entity에 대해 작동하는 base repository 제작

### DIFF
--- a/src/main/kotlin/com/waffle/areyouhere/core/manager/repository/ManagerRepository.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/core/manager/repository/ManagerRepository.kt
@@ -1,44 +1,13 @@
 package com.waffle.areyouhere.core.manager.repository
 
-import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
-import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createMutationQuery
-import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
 import com.waffle.areyouhere.core.manager.model.Manager
-import com.waffle.areyouhere.util.CustomJpql
-import io.smallrye.mutiny.coroutines.awaitSuspending
+import com.waffle.areyouhere.util.BaseRepository
 import org.hibernate.reactive.mutiny.Mutiny.SessionFactory
 import org.springframework.stereotype.Repository
 
 @Repository
 class ManagerRepository(
-    private val sessionFactory: SessionFactory,
-    private val context: JpqlRenderContext,
-) {
-
-    suspend fun findById(id: Long): Manager {
-        val query = jpql(CustomJpql) {
-            selectFrom(Manager::class)
-                .where(path(Manager::id).eq(id))
-        }
-        return sessionFactory.withSession {
-            it.createQuery(query, context).setMaxResults(1).singleResult
-        }.awaitSuspending()
-    }
-
-    suspend fun save(manager: Manager): Manager {
-        return sessionFactory.withTransaction { session, tx ->
-            session.persist(manager).chain(session::flush).replaceWith(manager)
-        }.awaitSuspending()
-    }
-
-    suspend fun deleteById(id: Long) {
-        val query = jpql(CustomJpql) {
-            deleteFrom(entity(Manager::class))
-                .where(path(Manager::id).eq(id))
-        }
-        sessionFactory.withTransaction { session, tx ->
-            session.createMutationQuery(query, context).executeUpdate()
-        }.awaitSuspending()
-    }
-}
+    override val sessionFactory: SessionFactory,
+    override val context: JpqlRenderContext,
+) : BaseRepository<Manager, Long>(sessionFactory, context, Manager::class, Manager::id)

--- a/src/main/kotlin/com/waffle/areyouhere/util/BaseRepository.kt
+++ b/src/main/kotlin/com/waffle/areyouhere/util/BaseRepository.kt
@@ -1,0 +1,69 @@
+package com.waffle.areyouhere.util
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entities
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createMutationQuery
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import org.hibernate.reactive.mutiny.Mutiny.SessionFactory
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+
+/**
+ * Base repository class for CRUD operations on entities with id.
+ *
+ * @param T The entity type.
+ * @param ID The id type of the entity.
+ * @param sessionFactory The Hibernate SessionFactory for database operations.
+ * @param context The JpqlRenderContext for rendering JPQL queries.
+ * @param idRef A reference to the id property of the entity.
+ */
+open class BaseRepository<T : Any, ID : Any>(
+    open val sessionFactory: SessionFactory,
+    open val context: JpqlRenderContext,
+    open val entityClass: KClass<T>,
+    open val idRef: KProperty1<T, ID?>,
+) {
+
+    suspend fun save(entity: T): T {
+        return sessionFactory.withTransaction { session ->
+            session.persist(entity)
+                .chain(session::flush)
+                .replaceWith(entity)
+        }.awaitSuspending()
+    }
+
+    suspend fun findById(id: ID): T? {
+        val query = SelectQueries.selectQuery(
+            returnType = entityClass,
+            distinct = false,
+            select = listOf(Entities.entity(entityClass)),
+            from = listOf(Entities.entity(entityClass)),
+            where = Predicates.equal(
+                Paths.path(Entities.entity(entityClass), idRef).toExpression(),
+                Expressions.value(id),
+            ),
+        )
+        return sessionFactory.withTransaction { session ->
+            session.createQuery(query, context).setMaxResults(1).singleResultOrNull
+        }.awaitSuspending()
+    }
+
+    suspend fun deleteById(id: ID): Int? {
+        val query = DeleteQueries.deleteQuery(
+            entity = Entities.entity(entityClass),
+            where = Predicates.equal(
+                Paths.path(Entities.entity(entityClass), idRef).toExpression(),
+                Expressions.value(id),
+            ),
+        )
+        return sessionFactory.withTransaction { session, tx ->
+            session.createMutationQuery(query, context).executeUpdate()
+        }.awaitSuspending()
+    }
+}

--- a/src/test/kotlin/com/waffle/areyouhere/core/manager/repository/ManagerRepositoryTest.kt
+++ b/src/test/kotlin/com/waffle/areyouhere/core/manager/repository/ManagerRepositoryTest.kt
@@ -21,15 +21,37 @@ class ManagerRepositoryTest {
                 name = "seongho",
                 password = "hi",
             )
-            val saveManager = managerRepository.save(manager)
+            val manager2 = Manager(
+                email = "aa@naver.com",
+                name = "ikjun",
+                password = "hehe",
+            )
+
+            val savedManager = managerRepository.save(manager)
+            val savedManager2 = managerRepository.save(manager2)
             val foundManager = managerRepository.findById(manager.id!!)
-            assertEquals(saveManager.id, foundManager!!.id)
+            assertEquals(savedManager.id, foundManager!!.id)
+            val foundManager2 = managerRepository.findById(manager2.id!!)
+            assertEquals(savedManager2.id, foundManager2!!.id)
+
+            val allManagers = managerRepository.findAll()
+            assertEquals(2, allManagers.size)
+            val managerCount = managerRepository.count()
+            assertEquals(2, managerCount)
 
             val deleteCount = managerRepository.deleteById(manager.id!!)
             assertEquals(1, deleteCount)
 
+            val managerCount2 = managerRepository.count()
+            assertEquals(1, managerCount2)
+
             val notFoundManager = managerRepository.findById(manager.id!!)
             assertEquals(null, notFoundManager)
+
+            val hasManager = managerRepository.existsById(manager.id!!)
+            assertEquals(false, hasManager)
+            val hasManager2 = managerRepository.existsById(manager2.id!!)
+            assertEquals(true, hasManager2)
         }
     }
 }

--- a/src/test/kotlin/com/waffle/areyouhere/core/manager/repository/ManagerRepositoryTest.kt
+++ b/src/test/kotlin/com/waffle/areyouhere/core/manager/repository/ManagerRepositoryTest.kt
@@ -23,7 +23,13 @@ class ManagerRepositoryTest {
             )
             val saveManager = managerRepository.save(manager)
             val foundManager = managerRepository.findById(manager.id!!)
-            assertEquals(saveManager.id, foundManager.id)
+            assertEquals(saveManager.id, foundManager!!.id)
+
+            val deleteCount = managerRepository.deleteById(manager.id!!)
+            assertEquals(1, deleteCount)
+
+            val notFoundManager = managerRepository.findById(manager.id!!)
+            assertEquals(null, notFoundManager)
         }
     }
 }


### PR DESCRIPTION
TODO: 필요한 공통 함수 더 추가하기
* `id`를 가진 entity에 대해, `id`를 통한 기본적인 CRUD 기능을 제공하는 `BaseRepository` 클래스를 제작했습니다.